### PR TITLE
chore: update teamcity fqdn

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -40,4 +40,4 @@ suites:
     attributes:
       teamcity:
         agents:
-          server_url: 'http://teamcity.hq.daptiv.com'
+          server_url: 'http://teamcity.daptiv.com'


### PR DESCRIPTION
- Updated TeamCity FQDN.  Changed from teamcity.hq.daptiv.com to teamcity.daptiv.com.