### PR TITLE
use deploysvc.pem for builds on new agents

### DIFF
--- a/packer/windows_2012r2_chef_13.8.5_visualstudio_2015/docker-compose.yml
+++ b/packer/windows_2012r2_chef_13.8.5_visualstudio_2015/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       EC2_SUBNET_ID: ${EC2_SUBNET_ID}
       EC2_VPC_ID: ${EC2_VPC_ID}
       PACKER_FILE: ${PACKER_FILE}
-      VALIDATION_KEY_PATH: /root/.chef/validation.pem
+      VALIDATION_KEY_PATH: /root/.chef/deploysvc.pem
     command: |
       bash -c 'bash -s <<EOF
       echo "Please enter the command to execute:"

--- a/packer/windows_2012r2_chef_13.8.5_visualstudio_2015/packer.json
+++ b/packer/windows_2012r2_chef_13.8.5_visualstudio_2015/packer.json
@@ -93,7 +93,7 @@
       "run_list": "recipe[visualstudio]",
       "server_url": "https://api.opscode.com/organizations/daptiv",
       "skip_install": "true",
-      "validation_client_name": "daptiv-validator",
+      "validation_client_name": "deploysvc",
       "validation_key_path": "{{user `validation_key_path`}}"
     },
     {

--- a/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_sql_server_2016_testagent/docker-compose.yml
+++ b/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_sql_server_2016_testagent/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       EC2_SUBNET_ID: ${EC2_SUBNET_ID}
       EC2_VPC_ID: ${EC2_VPC_ID}
       PACKER_FILE: ${PACKER_FILE}
-      VALIDATION_KEY_PATH: /root/.chef/validation.pem
+      VALIDATION_KEY_PATH: /root/.chef/deploysvc.pem
     command: |
       bash -c 'bash -s <<EOF
       echo "Please enter the command to execute:"

--- a/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_sql_server_2016_testagent/packer.json
+++ b/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_sql_server_2016_testagent/packer.json
@@ -88,7 +88,7 @@
       "run_list": "recipe[daptiv_ec2_environment],recipe[daptiv_buildagent_ppm_role]",
       "server_url": "https://api.opscode.com/organizations/daptiv",
       "skip_install": "true",
-      "validation_client_name": "daptiv-validator",
+      "validation_client_name": "deploysvc",
       "validation_key_path": "{{user `validation_key_path`}}"
     },
     {


### PR DESCRIPTION
@linusruth 

- Use `deploysvc.pem` on new build agents.  I left out the sql server 2016 build because I updated it in your branch already and this will make merge easier.