### PR TITLE
feat: set sql server trace flags, update validation key

### DIFF
--- a/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_sql_server_2016/docker-compose.yml
+++ b/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_sql_server_2016/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       EC2_SUBNET_ID: ${EC2_SUBNET_ID}
       EC2_VPC_ID: ${EC2_VPC_ID}
       PACKER_FILE: ${PACKER_FILE}
-      VALIDATION_KEY_PATH: /root/.chef/validation.pem
+      VALIDATION_KEY_PATH: /root/.chef/deploysvc.pem
     command: |
       bash -c 'bash -s <<EOF
       echo "Please enter the command to execute:"

--- a/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_sql_server_2016/packer.json
+++ b/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_sql_server_2016/packer.json
@@ -88,12 +88,16 @@
       "run_list": "recipe[daptiv_sql_server::install]",
       "server_url": "https://api.opscode.com/organizations/daptiv",
       "skip_install": "true",
-      "validation_client_name": "daptiv-validator",
+      "validation_client_name": "deploysvc",
       "validation_key_path": "{{user `validation_key_path`}}"
     },
     {
       "type": "powershell",
       "script": "./scripts/delete-cached-installation-packages.ps1"
+    },
+    {
+      "type": "powershell",
+      "script": "./scripts/configure_sql_server_trace_flags.ps1"
     },
     {
       "type": "powershell",

--- a/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_sql_server_2016/scripts/configure_sql_server_trace_flags.ps1
+++ b/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_sql_server_2016/scripts/configure_sql_server_trace_flags.ps1
@@ -1,0 +1,19 @@
+Write-Host 'Configuring SQL Server trace flags...'
+
+$server = $env:computerName
+$sqlservice = "MSSQLSERVER"
+$sqlagentservice = "SQLSERVERAGENT"
+$flagsToAdd = ";-T845;-T1140;-T3226;-T3427;-T4135;-T9481"
+
+[reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.SqlWmiManagement")
+$sqlwmi = New-Object Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer $server
+$wmisvc = $sqlwmi.Services | where {$_.name -eq $sqlservice}
+$wmisvc.StartupParameters = $wmisvc.StartupParameters + $flagsToAdd
+$wmisvc.Alter()
+
+$wmisvc.Stop()
+Start-Sleep -seconds 15
+$wmisvc.Start()
+
+$wmiAgent = $sqlwmi.Services | where {$_.name -eq $sqlagentservice}
+$wmiAgent.Start()


### PR DESCRIPTION
- Added script supplied by Bruce Sherwood to set the SQL Server trace flags the same as in all PPM environments.  This will make SQL Server on our test agents that much more like the real deal.  (Note: These flags cannot be set via the SQL Server installer.  They must be set after it is already installed.)

NOTE: this has already been tested in another branch.  But somehow that branch got screwed up and GitHub won't let me merge it.  So I've moved the relevant stuff into this branch.