### PR TITLE
Fix teamcity agent deploy

### DIFF
--- a/terraform/teamcity_agent/modules/instances/aws_instance.tf
+++ b/terraform/teamcity_agent/modules/instances/aws_instance.tf
@@ -24,6 +24,8 @@ resource "aws_instance" "my_instance" {
       bastion_private_key = "${file("${var.instance_private_key}")}"
     }
     inline = [
+      "sudo systemctl stop teamcity-agent",
+      "sudo systemctl stop docker",
       "sudo chef-client -o recipe['daptiv_chef_cleanup']; exit 0"
     ]
     when                  = "destroy"

--- a/terraform/teamcity_agent/modules/instances/aws_volume_attachment.tf
+++ b/terraform/teamcity_agent/modules/instances/aws_volume_attachment.tf
@@ -17,6 +17,7 @@ resource "aws_volume_attachment" "docker_volume" {
     }
     inline = [
       "sudo systemctl stop teamcity-agent",
+      "sudo systemctl stop docker",
       "VOLUME='/dev/xvdi1'; if mount | grep -cqw $VOLUME; then sudo umount -d $VOLUME; fi"
     ]
     when                  = "destroy"
@@ -42,6 +43,7 @@ resource "aws_volume_attachment" "logs_volume" {
     }
     inline = [
       "sudo systemctl stop teamcity-agent",
+      "sudo systemctl stop docker",
       "VOLUME='/dev/xvdj1'; if mount | grep -cqw $VOLUME; then sudo umount -d $VOLUME; fi"
     ]
     when                  = "destroy"
@@ -67,6 +69,7 @@ resource "aws_volume_attachment" "work_volume" {
     }
     inline = [
       "sudo systemctl stop teamcity-agent",
+      "sudo systemctl stop docker",
       "VOLUME='/dev/xvdk1'; if mount | grep -cqw $VOLUME; then sudo umount -d $VOLUME; fi"
     ]
     when                  = "destroy"

--- a/terraform/teamcity_agent/modules/instances/null_resource.tf
+++ b/terraform/teamcity_agent/modules/instances/null_resource.tf
@@ -83,7 +83,7 @@ resource "null_resource" "execute_teamcity_agent_configuration" {
 
     inline = [
       "sudo chown root:root /tmp/knife.rb",
-      "sudo mv /tmp/knife.rb ${var.chef_config_dir}knife.rb"
+      "sudo mv -f /tmp/knife.rb ${var.chef_config_dir}knife.rb"
     ]
   }
 }


### PR DESCRIPTION
- Ensure the knife.rb is overwritten on reruns.

- Ensure Docker is stopped before volumes are detached from a running instance.

- Ensure TeamCity and Docker are stopped during instance termination.  (In case of order of operations issues with the volume attachment termination.)