### PR TITLE
fix: create_chef_keys.sh parameter substitution

### DIFF
--- a/terraform/teamcity_agent/modules/instances/scripts/create_chef_keys.sh
+++ b/terraform/teamcity_agent/modules/instances/scripts/create_chef_keys.sh
@@ -1,17 +1,74 @@
 #!/usr/bin/env bash
 set -e
 
-DESTINATION_DIR="/etc/chef/"
-DESTINATION_DIR_PERMISSIONS="755"
-DESTINATION_FILE_PERMISSIONS="644"
-DESTINATION_OWNER="root"
-DESTINATION_GROUP="root"
+print_script_name () {
+  local NAME="${1}"
 
-verify_variable () {
-  if [ -z "${2}" ]; then
-    echo "Unable to set ${1}."
+  if [ -z "${NAME}" ]; then
+    echo "Running '${0##*/}'..."
+  else
+    echo "Running '${NAME}'..."
+  fi
+}
+
+verify_bash_version () {
+  local REQUIRED_VERSION="${1}"
+
+  local REQUIRED_MAJOR="$(printf "${REQUIRED_VERSION}" | cut -d '.' -f 1)"
+  local REQUIRED_MINOR="$(printf "${REQUIRED_VERSION}" | cut -d '.' -f 2)"
+  local ACTUAL_MAJOR="${BASH_VERSINFO[0]}"
+  local ACTUAL_MINOR="${BASH_VERSINFO[1]}"
+
+  if [ "${ACTUAL_MAJOR}" -lt "${REQUIRED_MAJOR}" ]; then
+    printf "Bash ${REQUIRED_VERSION} is required, "
+    printf "but ${BASH_VERSION} is installed.\n"
+    exit 1
+  elif [ "${ACTUAL_MINOR}" -lt "${REQUIRED_MINOR}" ]; then
+    printf "Bash ${REQUIRED_VERSION} is required, "
+    printf "but ${BASH_VERSION} is installed.\n"
     exit 1
   fi
+}
+
+verify_variable_exists () {
+  # Note: This function uses 'nameref' variables, introduced in bash 4.3.
+  verify_bash_version "4.3"
+
+  local VARIABLE_NAME="${1}"
+  local -n VARIABLE_VALUE="${1}"
+
+  if [ -z "${VARIABLE_VALUE}" ]; then
+    echo "Variable '${VARIABLE_NAME}' is empty."
+    exit 1
+  fi
+}
+
+verify_network_connectivity () {
+  local RETRY_DELAY_SEC="10"
+  local RETRY_COUNT="60"
+
+  echo "Verifying network connectivity..."
+  local DNS_SERVER="$(systemd-resolve --status \
+    | grep -i -m 1 -o 'DNS Servers.*' \
+    | cut -d ' ' -f 3)"
+
+  if [ -z "${DNS_SERVER}" ]; then
+    echo "Unable to determine DNS server address."
+    exit 1
+  fi
+
+  until ping -c 1 -q -w 1 "${DNS_SERVER}" > /dev/null
+  do
+    if [ "${RETRY_COUNT}" -ge "1" ]; then
+      echo "Unable to ping DNS server ${DNS_SERVER}, pausing ${RETRY_DELAY_SEC}sec..."
+      echo "Retries remaining: ${RETRY_COUNT}"
+      sleep "${RETRY_DELAY_SEC}"
+      ((RETRY_COUNT--))
+    else
+      echo "Network is still unavailable, aborting..."
+      exit 1
+    fi
+  done
 }
 
 get_ssm_parameter_value () {
@@ -24,26 +81,21 @@ get_ssm_parameter_value () {
     --with-decryption
 }
 
-print_script_name () {
-  local NAME="${1}"
-
-  if [ -z "${NAME}" ]; then
-    echo "Running '${0##*/}'..."
-  else
-    echo "Running '${NAME}'..."
-  fi
-}
-
 set_aws_default_region () {
   echo "Setting AWS_DEFAULT_REGION..."
   local METADATA_URL="http://169.254.169.254/latest/dynamic/instance-identity/document"
   export AWS_DEFAULT_REGION="$(curl -s "${METADATA_URL}" | jq -r .region)"
-  verify_variable 'AWS_DEFAULT_REGION' "${AWS_DEFAULT_REGION}"
+  verify_variable_exists "AWS_DEFAULT_REGION"
 }
 
 create_key () {
   local PARAMETER_NAME="${1}"
   local FILE_NAME="${2}"
+  local DESTINATION_DIR="/etc/chef/"
+  local DESTINATION_DIR_PERMISSIONS="755"
+  local DESTINATION_FILE_PERMISSIONS="644"
+  local DESTINATION_OWNER="root"
+  local DESTINATION_GROUP="root"
 
   echo "Creating key '${FILE_NAME}' in '${DESTINATION_DIR}'..."
   local VALUE="$(get_ssm_parameter_value "${PARAMETER_NAME}")"
@@ -51,9 +103,7 @@ create_key () {
   sudo mkdir -p "${DESTINATION_DIR}/" &>/dev/null
   sudo chown "${DESTINATION_OWNER}":"${DESTINATION_GROUP}" "${DESTINATION_DIR}/"
   sudo chmod "${DESTINATION_DIR_PERMISSIONS}" "${DESTINATION_DIR}/"
-  printf "%s" "${VALUE}" | \
-    sed 's/- /-\n/g' | \
-    sed 's/ -/\n-/g' | \
+  printf "%s" "${VALUE// /$'\n'}" | \
     sudo -u "${DESTINATION_OWNER}" \
     tee "${DESTINATION_DIR}/${FILE_NAME}" &>/dev/null
   sudo chmod "${DESTINATION_FILE_PERMISSIONS}" "${DESTINATION_DIR}/${FILE_NAME}"
@@ -61,6 +111,7 @@ create_key () {
 
 main () {
   print_script_name "create_chef_keys.sh"
+  verify_network_connectivity
   set_aws_default_region
   create_key "/chef/keys/deploysvc" "deploysvc.pem"
   create_key "/chef/keys/dev-encrypted-data-bag-secret" "encrypted_data_bag_secret"


### PR DESCRIPTION
- Fix character replacement (spaces to newlines) in create_chef_keys.sh.  For some reason it was failing on the GoCD agents (Ubuntu 18.04) but not on the TeamCity agents (Ubuntu 16.04).  I'm not sure what the exact difference is, but this should fix it.  The new way is much more efficient too, using Bash's built in parameter substitution directly within the printf call, rather than piping it into sed twice.

- Synchronize the functions in create_chef_keys.sh between this repo and GoCD.