### PR TITLE
chore: net test not needed for terraform, and won't work on 16.04

### DIFF
--- a/terraform/teamcity_agent/modules/instances/scripts/create_chef_keys.sh
+++ b/terraform/teamcity_agent/modules/instances/scripts/create_chef_keys.sh
@@ -111,7 +111,6 @@ create_key () {
 
 main () {
   print_script_name "create_chef_keys.sh"
-  verify_network_connectivity
   set_aws_default_region
   create_key "/chef/keys/deploysvc" "deploysvc.pem"
   create_key "/chef/keys/dev-encrypted-data-bag-secret" "encrypted_data_bag_secret"


### PR DESCRIPTION
- The TeamCity agents are stragglers, stuck on Ubuntu 16.04.  The network connectivity function requires 18.04 because it depends on the --status flag that's only in newer versions of systemd.  Anyway, it's not needed for use by Terraform since Terraform is connecting via SSH to run it, so we know there's network connectivity.  ;P