### PR TITLE
fix: substitution in deploysvc.pem

### DIFF
--- a/terraform/teamcity_agent/modules/instances/scripts/create_chef_keys.sh
+++ b/terraform/teamcity_agent/modules/instances/scripts/create_chef_keys.sh
@@ -103,7 +103,10 @@ create_key () {
   sudo mkdir -p "${DESTINATION_DIR}/" &>/dev/null
   sudo chown "${DESTINATION_OWNER}":"${DESTINATION_GROUP}" "${DESTINATION_DIR}/"
   sudo chmod "${DESTINATION_DIR_PERMISSIONS}" "${DESTINATION_DIR}/"
-  printf "%s" "${VALUE// /$'\n'}" | \
+  printf "%s" "${VALUE}" | \
+    sed 's/- /-\n/g' | \
+    sed 's/ -/\n-/g' | \
+    sed '/^-/! s/ /\n/g' | \
     sudo -u "${DESTINATION_OWNER}" \
     tee "${DESTINATION_DIR}/${FILE_NAME}" &>/dev/null
   sudo chmod "${DESTINATION_FILE_PERMISSIONS}" "${DESTINATION_DIR}/${FILE_NAME}"


### PR DESCRIPTION
- Fix character substitution in create_chef_keys.sh to support both Chef secret and Chef private key file types.  (More complex substitution is required.)