### PR TITLE
Buildagent fix

### DIFF
--- a/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_buildagent/packer.json
+++ b/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_buildagent/packer.json
@@ -75,6 +75,11 @@
   ],
   "provisioners": [
     {
+      "type": "file",
+      "destination": "c:/chef/encrypted_data_bag_secret",
+      "source": "/root/.chef/{{user `chef_secret_file`}}"
+    },
+    {
       "type": "chef-client",
       "chef_environment": "dev",
       "guest_os_type": "windows",
@@ -84,15 +89,6 @@
       "skip_install": "true",
       "validation_client_name": "deploysvc",
       "validation_key_path": "{{user `validation_key_path`}}"
-    },
-    {
-      "type": "file",
-      "destination": "c:/windows/temp/encrypted_data_bag_secret",
-      "source": "/root/.chef/{{user `chef_secret_file`}}"
-    },
-    {
-      "type": "shell",
-      "inline": ["xcopy /s /Y c:/windows/temp/encrypted_data_bag_secret c:/chef/"]
     },
     {
       "type": "powershell",

--- a/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_buildagent/packer.json
+++ b/packer/windows_2012r2_chef_13.8.5_visualstudio_2015_buildagent/packer.json
@@ -37,7 +37,7 @@
       "communicator": "winrm",
       "force_delete_snapshot": true,
       "force_deregister": true,
-      "instance_type": "c4.large",
+      "instance_type": "t2.medium",
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
@@ -87,8 +87,12 @@
     },
     {
       "type": "file",
-      "destination": "c:/chef/encrypted_data_bag_secret",
+      "destination": "c:/windows/temp/encrypted_data_bag_secret",
       "source": "/root/.chef/{{user `chef_secret_file`}}"
+    },
+    {
+      "type": "shell",
+      "inline": ["xcopy /s /Y c:/windows/temp/encrypted_data_bag_secret c:/chef/"]
     },
     {
       "type": "powershell",


### PR DESCRIPTION
@linusruth 

- The 'buildagent' TeamCity agent needs a different encryption key during the Chef run (ops key).  This simply required moving the file provisioner for the key copy to before the chef provisioner.
- No need to run this build on such a large instance type...it completes relatively quickly (34 minutes) on a t2.medium.

Relevant TP Story: https://daptiv.tpondemand.com/entity/229006-teamcity-agent-deployments-fixed