### PR TITLE
230028 deploy ci

### DIFF
--- a/gocd/cicdus/cicdus_environment.gocd.yaml
+++ b/gocd/cicdus/cicdus_environment.gocd.yaml
@@ -2,3 +2,6 @@ environments:
   cicdus:
     pipelines:
       - cicdus_teamcity_ubuntu_agent_deploy
+      - cicdus_teamcity_build_agent_deploy
+      - cicdus_teamcity_cognos_agent_deploy
+      - cicdus_teamcity_test_agent_deploy

--- a/gocd/cicdus/cicdus_environment.gocd.yaml
+++ b/gocd/cicdus/cicdus_environment.gocd.yaml
@@ -2,4 +2,3 @@ environments:
   cicdus:
     pipelines:
       - cicdus_teamcity_ubuntu_agent_deploy
-      - cicdus_teamcity_test_agent_deploy

--- a/gocd/cicdus/cicdus_environment.gocd.yaml
+++ b/gocd/cicdus/cicdus_environment.gocd.yaml
@@ -1,4 +1,5 @@
 environments:
   cicdus:
     pipelines:
-      - cicdus_teamcity_agent_deploy
+      - cicdus_teamcity_ubuntu_agent_deploy
+      - cicdus_teamcity_test_agent_deploy

--- a/gocd/cicdus/cicdus_teamcity_build_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_build_agent_deploy.gocd.yaml
@@ -25,7 +25,7 @@ pipelines:
     materials:
       "ops_ec2_deployer":
         git: git@github.com:daptiv/ops_ec2_deployer.git
-        branch: master
+        branch: 230028_deploy_ci
         destination: ops_ec2_deployer
     stages:
       - "Deploy":

--- a/gocd/cicdus/cicdus_teamcity_build_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_build_agent_deploy.gocd.yaml
@@ -1,0 +1,73 @@
+pipelines:
+  "cicdus_teamcity_build_agent_deploy":
+    environment_variables:
+      AWS_CRED_DIR: /var/go/.aws/
+      AWS_DEFAULT_REGION: us-east-1
+      CHEF_CONFIG_DIR: /etc/chef/
+      CHEF_SECRET_FILE: encrypted_data_bag_secret
+      DC_USER: us\us_domjoin
+      DOMAIN_CONTROLLER: US-DC01.us.daptiv.cloud
+      EC2_ROLE_ARN: arn:aws:iam::147491244536:role/GO_CP_US_CICD
+      NODE_TYPES: buildagent_windows_chef13
+      PATCH_LEVEL: 20180518
+      WIN_DOMAIN_USER: us\us_deploysvc
+      WIN_LOCAL_USER: Administrator
+    secure_variables: # https://api.gocd.org/current/#encrypt-a-plain-text-value
+      DC_PASS: AES:w9NH2Zk+VRENh9UL7lmSew==:JEXZf0wrMwbjHqXAeMroUQ==
+      AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
+      AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
+      SLACK_URL_SUFFIX: AES:Gf9FJhvSPZvAwNUN6vrv6A==:8EV1Z57EwfIpksT47M2gV50E0DfJF/WeXnMdEDUvHO5X65AKqCwJEZUPR8fqpQnb
+      WIN_DOMAIN_PASS: AES:eoSRfPVUr52uHiqjAhU2HA==:UZu+wR9bo8hQ4eQIDnhc34Kz8+OmVSqRXzKqVhIZB0M=
+      WIN_LOCAL_PASS: AES:+ScLaate2XUIW/7fPLstBw==:0ButywWhDkkQNig83ut7ww==
+    group: teamcity
+    label_template: "${COUNT}"
+    locking: off
+    materials:
+      "ops_ec2_deployer":
+        git: git@github.com:daptiv/ops_ec2_deployer.git
+        branch: 230028_deploy_ci
+        destination: ops_ec2_deployer
+    stages:
+      - "Deploy":
+          approval: manual
+          clean_workspace: true
+          jobs:
+            "Execute":
+              resources:
+                - docker
+              tasks:
+                - exec:
+                    run_if: passed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose pull"
+                - exec:
+                    run_if: passed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose run --rm chefdk 'rake notify[\"started\"] -f rakefile_deploy.rb'"
+                - exec:
+                    run_if: passed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose -f docker-compose.yml run --rm chefdk 'gem uninstall winrm -v 2.2.3 --force && rake deploy -f rakefile_deploy.rb'"
+                - exec:
+                    run_if: passed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose run --rm chefdk 'rake notify[\"passed\"] -f rakefile_deploy.rb'"
+                - exec:
+                    run_if: failed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose run --rm chefdk 'rake notify[\"failed\"] -f rakefile_deploy.rb'"

--- a/gocd/cicdus/cicdus_teamcity_build_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_build_agent_deploy.gocd.yaml
@@ -25,7 +25,7 @@ pipelines:
     materials:
       "ops_ec2_deployer":
         git: git@github.com:daptiv/ops_ec2_deployer.git
-        branch: 230028_deploy_ci
+        branch: master
         destination: ops_ec2_deployer
     stages:
       - "Deploy":

--- a/gocd/cicdus/cicdus_teamcity_cognos_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_cognos_agent_deploy.gocd.yaml
@@ -1,0 +1,73 @@
+pipelines:
+  "cicdus_teamcity_cognos_agent_deploy":
+    environment_variables:
+      AWS_CRED_DIR: /var/go/.aws/
+      AWS_DEFAULT_REGION: us-east-1
+      CHEF_CONFIG_DIR: /etc/chef/
+      CHEF_SECRET_FILE: encrypted_data_bag_secret
+      DC_USER: us\us_domjoin
+      DOMAIN_CONTROLLER: US-DC01.us.daptiv.cloud
+      EC2_ROLE_ARN: arn:aws:iam::147491244536:role/GO_CP_US_CICD
+      NODE_TYPES: testagent_cognos_windows_chef13
+      PATCH_LEVEL: 20180518
+      WIN_DOMAIN_USER: us\us_deploysvc
+      WIN_LOCAL_USER: Administrator
+    secure_variables: # https://api.gocd.org/current/#encrypt-a-plain-text-value
+      DC_PASS: AES:w9NH2Zk+VRENh9UL7lmSew==:JEXZf0wrMwbjHqXAeMroUQ==
+      AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
+      AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
+      SLACK_URL_SUFFIX: AES:Gf9FJhvSPZvAwNUN6vrv6A==:8EV1Z57EwfIpksT47M2gV50E0DfJF/WeXnMdEDUvHO5X65AKqCwJEZUPR8fqpQnb
+      WIN_DOMAIN_PASS: AES:eoSRfPVUr52uHiqjAhU2HA==:UZu+wR9bo8hQ4eQIDnhc34Kz8+OmVSqRXzKqVhIZB0M=
+      WIN_LOCAL_PASS: AES:+ScLaate2XUIW/7fPLstBw==:0ButywWhDkkQNig83ut7ww==
+    group: teamcity
+    label_template: "${COUNT}"
+    locking: off
+    materials:
+      "ops_ec2_deployer":
+        git: git@github.com:daptiv/ops_ec2_deployer.git
+        branch: 230028_deploy_ci
+        destination: ops_ec2_deployer
+    stages:
+      - "Deploy":
+          approval: manual
+          clean_workspace: true
+          jobs:
+            "Execute":
+              resources:
+                - docker
+              tasks:
+                - exec:
+                    run_if: passed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose pull"
+                - exec:
+                    run_if: passed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose run --rm chefdk 'rake notify[\"started\"] -f rakefile_deploy.rb'"
+                - exec:
+                    run_if: passed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose -f docker-compose.yml run --rm chefdk 'gem uninstall winrm -v 2.2.3 --force && rake deploy -f rakefile_deploy.rb'"
+                - exec:
+                    run_if: passed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose run --rm chefdk 'rake notify[\"passed\"] -f rakefile_deploy.rb'"
+                - exec:
+                    run_if: failed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose run --rm chefdk 'rake notify[\"failed\"] -f rakefile_deploy.rb'"

--- a/gocd/cicdus/cicdus_teamcity_cognos_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_cognos_agent_deploy.gocd.yaml
@@ -25,7 +25,7 @@ pipelines:
     materials:
       "ops_ec2_deployer":
         git: git@github.com:daptiv/ops_ec2_deployer.git
-        branch: 230028_deploy_ci
+        branch: master
         destination: ops_ec2_deployer
     stages:
       - "Deploy":

--- a/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
@@ -22,7 +22,7 @@ pipelines:
     materials:
       "ops_ec2_deployer":
         git: git@github.com:daptiv/ops_ec2_deployer.git
-        branch: master
+        branch: 230028_deploy_ci
         destination: ops_ec2_deployer
     stages:
       - "Deploy":

--- a/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
@@ -6,6 +6,7 @@ pipelines:
       CHEF_SECRET_FILE: encrypted_data_bag_secret
       DC_USER: us\us_domjoin
       DOMAIN_CONTROLLER: US-DC01.us.daptiv.cloud
+      EC2_ROLE_ARN: arn:aws:iam::147491244536:role/GO_CP_US_CICD
       NODE_TYPES: testagent_windows_chef13
       PATCH_LEVEL: 20180518
       WIN_DOMAIN_USER: us\us_deploysvc

--- a/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
@@ -44,7 +44,7 @@ pipelines:
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose run --rm chefdk 'rake notify[\"started\"]'"
+                      - "docker-compose run --rm chefdk 'rake notify[\"started\"] -f rakefile_deploy.rb'"
                 - exec:
                     run_if: passed
                     working_directory: ops_ec2_deployer
@@ -58,11 +58,11 @@ pipelines:
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose run --rm chefdk 'rake notify[\"passed\"]'"
+                      - "docker-compose run --rm chefdk 'rake notify[\"passed\"] -f rakefile_deploy.rb'"
                 - exec:
                     run_if: failed
                     working_directory: ops_ec2_deployer
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose run --rm chefdk 'rake notify[\"failed\"]'"
+                      - "docker-compose run --rm chefdk 'rake notify[\"failed\"] -f rakefile_deploy.rb'"

--- a/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
@@ -1,0 +1,68 @@
+pipelines:
+  "cicdus_teamcity_test_agent_deploy":
+    environment_variables:
+      AWS_CRED_DIR: /var/go/.aws/
+      CHEF_CONFIG_DIR: /etc/chef/
+      CHEF_SECRET_FILE: encrypted_data_bag_secret
+      DC_USER: us\us_domjoin
+      DOMAIN_CONTROLLER: US-DC01.us.daptiv.cloud
+      PATCH_LEVEL: 20180518
+      WIN_DOMAIN_USER: us\us_deploysvc
+    secure_variables: # https://api.gocd.org/current/#encrypt-a-plain-text-value
+      DC_PASS: AES:w9NH2Zk+VRENh9UL7lmSew==:JEXZf0wrMwbjHqXAeMroUQ==
+      AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
+      AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
+      SLACK_URL_SUFFIX: AES:Gf9FJhvSPZvAwNUN6vrv6A==:8EV1Z57EwfIpksT47M2gV50E0DfJF/WeXnMdEDUvHO5X65AKqCwJEZUPR8fqpQnb
+      WIN_DOMAIN_PASS: AES:eoSRfPVUr52uHiqjAhU2HA==:UZu+wR9bo8hQ4eQIDnhc34Kz8+OmVSqRXzKqVhIZB0M=
+    group: teamcity
+    label_template: "${COUNT}"
+    locking: off
+    materials:
+      "ops_ec2_deployer":
+        git: git@github.com:daptiv/ops_ec2_deployer.git
+        branch: master
+        destination: teamcity
+    stages:
+      - "Deploy":
+          approval: manual
+          clean_workspace: true
+          jobs:
+            "Execute":
+              resources:
+                - docker
+              tasks:
+                - exec:
+                    run_if: passed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose pull"
+                - exec:
+                    run_if: passed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose run --rm chefdk 'rake notify[\"started\"]'"
+                - exec:
+                    run_if: passed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose -f docker-compose.yml run --rm chefdk 'gem uninstall winrm -v 2.2.3 --force && rake deploy -f rakefile_deploy.rb'"
+                - exec:
+                    run_if: passed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose run --rm chefdk 'rake notify[\"passed\"]'"
+                - exec:
+                    run_if: failed
+                    working_directory: ops_ec2_deployer
+                    command: /bin/bash
+                    arguments:
+                      - -c
+                      - "docker-compose run --rm chefdk 'rake notify[\"failed\"]'"

--- a/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
@@ -21,7 +21,7 @@ pipelines:
       "ops_ec2_deployer":
         git: git@github.com:daptiv/ops_ec2_deployer.git
         branch: master
-        destination: teamcity
+        destination: ops_ec2_deployer
     stages:
       - "Deploy":
           approval: manual

--- a/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
@@ -13,8 +13,8 @@ pipelines:
       WIN_DOMAIN_USER: us\us_deploysvc
     secure_variables: # https://api.gocd.org/current/#encrypt-a-plain-text-value
       DC_PASS: AES:w9NH2Zk+VRENh9UL7lmSew==:JEXZf0wrMwbjHqXAeMroUQ==
-      AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
-      AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
+      GO_AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
+      GO_AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
       SLACK_URL_SUFFIX: AES:Gf9FJhvSPZvAwNUN6vrv6A==:8EV1Z57EwfIpksT47M2gV50E0DfJF/WeXnMdEDUvHO5X65AKqCwJEZUPR8fqpQnb
       WIN_DOMAIN_PASS: AES:eoSRfPVUr52uHiqjAhU2HA==:UZu+wR9bo8hQ4eQIDnhc34Kz8+OmVSqRXzKqVhIZB0M=
     group: teamcity

--- a/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
@@ -6,6 +6,7 @@ pipelines:
       CHEF_SECRET_FILE: encrypted_data_bag_secret
       DC_USER: us\us_domjoin
       DOMAIN_CONTROLLER: US-DC01.us.daptiv.cloud
+      NODE_TYPES: testagent_windows_chef13
       PATCH_LEVEL: 20180518
       WIN_DOMAIN_USER: us\us_deploysvc
     secure_variables: # https://api.gocd.org/current/#encrypt-a-plain-text-value

--- a/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
@@ -13,8 +13,8 @@ pipelines:
       WIN_DOMAIN_USER: us\us_deploysvc
     secure_variables: # https://api.gocd.org/current/#encrypt-a-plain-text-value
       DC_PASS: AES:w9NH2Zk+VRENh9UL7lmSew==:JEXZf0wrMwbjHqXAeMroUQ==
-      GO_AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
-      GO_AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
+      AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
+      AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
       SLACK_URL_SUFFIX: AES:Gf9FJhvSPZvAwNUN6vrv6A==:8EV1Z57EwfIpksT47M2gV50E0DfJF/WeXnMdEDUvHO5X65AKqCwJEZUPR8fqpQnb
       WIN_DOMAIN_PASS: AES:eoSRfPVUr52uHiqjAhU2HA==:UZu+wR9bo8hQ4eQIDnhc34Kz8+OmVSqRXzKqVhIZB0M=
     group: teamcity

--- a/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
@@ -25,7 +25,7 @@ pipelines:
     materials:
       "ops_ec2_deployer":
         git: git@github.com:daptiv/ops_ec2_deployer.git
-        branch: 230028_deploy_ci
+        branch: master
         destination: ops_ec2_deployer
     stages:
       - "Deploy":

--- a/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
@@ -2,6 +2,7 @@ pipelines:
   "cicdus_teamcity_test_agent_deploy":
     environment_variables:
       AWS_CRED_DIR: /var/go/.aws/
+      AWS_DEFAULT_REGION: us-east-1
       CHEF_CONFIG_DIR: /etc/chef/
       CHEF_SECRET_FILE: encrypted_data_bag_secret
       DC_USER: us\us_domjoin

--- a/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_test_agent_deploy.gocd.yaml
@@ -11,12 +11,14 @@ pipelines:
       NODE_TYPES: testagent_windows_chef13
       PATCH_LEVEL: 20180518
       WIN_DOMAIN_USER: us\us_deploysvc
+      WIN_LOCAL_USER: Administrator
     secure_variables: # https://api.gocd.org/current/#encrypt-a-plain-text-value
       DC_PASS: AES:w9NH2Zk+VRENh9UL7lmSew==:JEXZf0wrMwbjHqXAeMroUQ==
       AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
       AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
       SLACK_URL_SUFFIX: AES:Gf9FJhvSPZvAwNUN6vrv6A==:8EV1Z57EwfIpksT47M2gV50E0DfJF/WeXnMdEDUvHO5X65AKqCwJEZUPR8fqpQnb
       WIN_DOMAIN_PASS: AES:eoSRfPVUr52uHiqjAhU2HA==:UZu+wR9bo8hQ4eQIDnhc34Kz8+OmVSqRXzKqVhIZB0M=
+      WIN_LOCAL_PASS: AES:+ScLaate2XUIW/7fPLstBw==:0ButywWhDkkQNig83ut7ww==
     group: teamcity
     label_template: "${COUNT}"
     locking: off

--- a/gocd/cicdus/cicdus_teamcity_ubuntu_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_ubuntu_agent_deploy.gocd.yaml
@@ -1,5 +1,5 @@
 pipelines:
-  "cicdus_teamcity_agent_deploy":
+  "cicdus_teamcity_ubuntu_agent_deploy":
     environment_variables:
       AWS_CRED_DIR: /var/go/.aws/
       CHEF_CONFIG_DIR: /etc/chef/

--- a/gocd/cicdus/dev_environment.gocd.yaml
+++ b/gocd/cicdus/dev_environment.gocd.yaml
@@ -2,3 +2,4 @@ environments:
   dev:
     pipelines:
       - cicdus_teamcity_test_agent_deploy
+      - cicdus_teamcity_cognos_agent_deploy

--- a/gocd/cicdus/dev_environment.gocd.yaml
+++ b/gocd/cicdus/dev_environment.gocd.yaml
@@ -1,0 +1,4 @@
+environments:
+  dev:
+    pipelines:
+      - cicdus_teamcity_test_agent_deploy

--- a/gocd/cicdus/dev_environment.gocd.yaml
+++ b/gocd/cicdus/dev_environment.gocd.yaml
@@ -1,6 +1,0 @@
-environments:
-  dev:
-    pipelines:
-      - cicdus_teamcity_build_agent_deploy
-      - cicdus_teamcity_cognos_agent_deploy
-      - cicdus_teamcity_test_agent_deploy

--- a/gocd/cicdus/dev_environment.gocd.yaml
+++ b/gocd/cicdus/dev_environment.gocd.yaml
@@ -1,5 +1,6 @@
 environments:
   dev:
     pipelines:
-      - cicdus_teamcity_test_agent_deploy
+      - cicdus_teamcity_build_agent_deploy
       - cicdus_teamcity_cognos_agent_deploy
+      - cicdus_teamcity_test_agent_deploy


### PR DESCRIPTION
@linusruth 

- Build, Cognos, and Test TeamCity agent pipelines.  These replace the *Deploy_CI* TeamCity build.

Related PRs:
- https://github.com/daptiv/ops_ec2_deployer/pull/120
- https://github.com/daptiv/terraform_cicd/pull/56