### PR TITLE
feat: destroyer pipelines, approval requirements

### DIFF
--- a/gocd/cicdus/cicdus_environment.gocd.yaml
+++ b/gocd/cicdus/cicdus_environment.gocd.yaml
@@ -3,5 +3,8 @@ environments:
     pipelines:
       - cicdus_teamcity_ubuntu_agent_deploy
       - cicdus_teamcity_build_agent_deploy
+      - cicdus_teamcity_build_agent_destroy
       - cicdus_teamcity_cognos_agent_deploy
+      - cicdus_teamcity_cognos_agent_destroy
       - cicdus_teamcity_test_agent_deploy
+      - cicdus_teamcity_test_agent_destroy

--- a/gocd/cicdus/cicdus_teamcity_build_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_build_agent_deploy.gocd.yaml
@@ -29,7 +29,11 @@ pipelines:
         destination: ops_ec2_deployer
     stages:
       - "deploy":
-          approval: manual
+          approval:
+            type: manual
+            roles:
+              - US_GoCD_RoleTeamBork
+              - US_GoCD_RoleTeamNetOps
           clean_workspace: true
           jobs:
             "execute":

--- a/gocd/cicdus/cicdus_teamcity_build_agent_destroy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_build_agent_destroy.gocd.yaml
@@ -14,7 +14,7 @@ pipelines:
       AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
       AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
       SLACK_URL_SUFFIX: AES:Gf9FJhvSPZvAwNUN6vrv6A==:8EV1Z57EwfIpksT47M2gV50E0DfJF/WeXnMdEDUvHO5X65AKqCwJEZUPR8fqpQnb
-    group: teamcity
+    group: teamcity_destroyer
     label_template: "${COUNT}"
     locking: off
     materials:

--- a/gocd/cicdus/cicdus_teamcity_build_agent_destroy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_build_agent_destroy.gocd.yaml
@@ -1,24 +1,19 @@
 pipelines:
-  "cicdus_teamcity_test_agent_deploy":
+  "cicdus_teamcity_build_agent_destroy":
     environment_variables:
       AWS_CRED_DIR: /var/go/.aws/
       AWS_DEFAULT_REGION: us-east-1
       CHEF_CONFIG_DIR: /etc/chef/
-      CHEF_SECRET_FILE: encrypted_data_bag_secret
       DC_USER: us\us_domjoin
       DOMAIN_CONTROLLER: us-dc01.us.daptiv.cloud
       EC2_ROLE_ARN: arn:aws:iam::147491244536:role/GO_CP_US_CICD
-      NODE_TYPES: testagent_windows_chef13
-      PATCH_LEVEL: 20181014
-      WIN_DOMAIN_USER: us\us_deploysvc
-      WIN_LOCAL_USER: Administrator
+      NODE_TYPES: buildagent_windows_chef13
+      PATCH_LEVEL:
     secure_variables: # https://api.gocd.org/current/#encrypt-a-plain-text-value
       DC_PASS: AES:w9NH2Zk+VRENh9UL7lmSew==:JEXZf0wrMwbjHqXAeMroUQ==
       AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
       AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
       SLACK_URL_SUFFIX: AES:Gf9FJhvSPZvAwNUN6vrv6A==:8EV1Z57EwfIpksT47M2gV50E0DfJF/WeXnMdEDUvHO5X65AKqCwJEZUPR8fqpQnb
-      WIN_DOMAIN_PASS: AES:eoSRfPVUr52uHiqjAhU2HA==:UZu+wR9bo8hQ4eQIDnhc34Kz8+OmVSqRXzKqVhIZB0M=
-      WIN_LOCAL_PASS: AES:+ScLaate2XUIW/7fPLstBw==:0ButywWhDkkQNig83ut7ww==
     group: teamcity
     label_template: "${COUNT}"
     locking: off
@@ -28,7 +23,7 @@ pipelines:
         branch: master
         destination: ops_ec2_deployer
     stages:
-      - "deploy":
+      - "destroyer":
           approval:
             type: manual
             roles:
@@ -36,7 +31,7 @@ pipelines:
               - US_GoCD_RoleTeamNetOps
           clean_workspace: true
           jobs:
-            "execute":
+            "destroy":
               resources:
                 - docker
               tasks:
@@ -53,25 +48,25 @@ pipelines:
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose run --rm chefdk 'rake notify[\"started\"] -f rakefile_deploy.rb'"
+                      - "docker-compose run --rm chefdk 'rake notify[\"started\"] -f rakefile_destroy.rb'"
                 - exec:
                     run_if: passed
                     working_directory: ops_ec2_deployer
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose -f docker-compose.yml run --rm chefdk 'gem uninstall winrm -v 2.2.3 --force && rake deploy -f rakefile_deploy.rb'"
+                      - "docker-compose run --rm chefdk 'rake destroy -f rakefile_destroy.rb'"
                 - exec:
                     run_if: passed
                     working_directory: ops_ec2_deployer
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose run --rm chefdk 'rake notify[\"passed\"] -f rakefile_deploy.rb'"
+                      - "docker-compose run --rm chefdk 'rake notify[\"passed\"] -f rakefile_destroy.rb'"
                 - exec:
                     run_if: failed
                     working_directory: ops_ec2_deployer
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose run --rm chefdk 'rake notify[\"failed\"] -f rakefile_deploy.rb'"
+                      - "docker-compose run --rm chefdk 'rake notify[\"failed\"] -f rakefile_destroy.rb'"

--- a/gocd/cicdus/cicdus_teamcity_cognos_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_cognos_agent_deploy.gocd.yaml
@@ -29,7 +29,11 @@ pipelines:
         destination: ops_ec2_deployer
     stages:
       - "deploy":
-          approval: manual
+          approval:
+            type: manual
+            roles:
+              - US_GoCD_RoleTeamBork
+              - US_GoCD_RoleTeamNetOps
           clean_workspace: true
           jobs:
             "execute":

--- a/gocd/cicdus/cicdus_teamcity_cognos_agent_destroy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_cognos_agent_destroy.gocd.yaml
@@ -14,7 +14,7 @@ pipelines:
       AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
       AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
       SLACK_URL_SUFFIX: AES:Gf9FJhvSPZvAwNUN6vrv6A==:8EV1Z57EwfIpksT47M2gV50E0DfJF/WeXnMdEDUvHO5X65AKqCwJEZUPR8fqpQnb
-    group: teamcity
+    group: teamcity_destroyer
     label_template: "${COUNT}"
     locking: off
     materials:

--- a/gocd/cicdus/cicdus_teamcity_cognos_agent_destroy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_cognos_agent_destroy.gocd.yaml
@@ -1,24 +1,19 @@
 pipelines:
-  "cicdus_teamcity_test_agent_deploy":
+  "cicdus_teamcity_cognos_agent_destroy":
     environment_variables:
       AWS_CRED_DIR: /var/go/.aws/
       AWS_DEFAULT_REGION: us-east-1
       CHEF_CONFIG_DIR: /etc/chef/
-      CHEF_SECRET_FILE: encrypted_data_bag_secret
       DC_USER: us\us_domjoin
       DOMAIN_CONTROLLER: us-dc01.us.daptiv.cloud
       EC2_ROLE_ARN: arn:aws:iam::147491244536:role/GO_CP_US_CICD
-      NODE_TYPES: testagent_windows_chef13
-      PATCH_LEVEL: 20181014
-      WIN_DOMAIN_USER: us\us_deploysvc
-      WIN_LOCAL_USER: Administrator
+      NODE_TYPES: testagent_cognos_windows_chef13
+      PATCH_LEVEL:
     secure_variables: # https://api.gocd.org/current/#encrypt-a-plain-text-value
       DC_PASS: AES:w9NH2Zk+VRENh9UL7lmSew==:JEXZf0wrMwbjHqXAeMroUQ==
       AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
       AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
       SLACK_URL_SUFFIX: AES:Gf9FJhvSPZvAwNUN6vrv6A==:8EV1Z57EwfIpksT47M2gV50E0DfJF/WeXnMdEDUvHO5X65AKqCwJEZUPR8fqpQnb
-      WIN_DOMAIN_PASS: AES:eoSRfPVUr52uHiqjAhU2HA==:UZu+wR9bo8hQ4eQIDnhc34Kz8+OmVSqRXzKqVhIZB0M=
-      WIN_LOCAL_PASS: AES:+ScLaate2XUIW/7fPLstBw==:0ButywWhDkkQNig83ut7ww==
     group: teamcity
     label_template: "${COUNT}"
     locking: off
@@ -28,7 +23,7 @@ pipelines:
         branch: master
         destination: ops_ec2_deployer
     stages:
-      - "deploy":
+      - "destroyer":
           approval:
             type: manual
             roles:
@@ -36,7 +31,7 @@ pipelines:
               - US_GoCD_RoleTeamNetOps
           clean_workspace: true
           jobs:
-            "execute":
+            "destroy":
               resources:
                 - docker
               tasks:
@@ -53,25 +48,25 @@ pipelines:
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose run --rm chefdk 'rake notify[\"started\"] -f rakefile_deploy.rb'"
+                      - "docker-compose run --rm chefdk 'rake notify[\"started\"] -f rakefile_destroy.rb'"
                 - exec:
                     run_if: passed
                     working_directory: ops_ec2_deployer
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose -f docker-compose.yml run --rm chefdk 'gem uninstall winrm -v 2.2.3 --force && rake deploy -f rakefile_deploy.rb'"
+                      - "docker-compose run --rm chefdk 'rake destroy -f rakefile_destroy.rb'"
                 - exec:
                     run_if: passed
                     working_directory: ops_ec2_deployer
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose run --rm chefdk 'rake notify[\"passed\"] -f rakefile_deploy.rb'"
+                      - "docker-compose run --rm chefdk 'rake notify[\"passed\"] -f rakefile_destroy.rb'"
                 - exec:
                     run_if: failed
                     working_directory: ops_ec2_deployer
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose run --rm chefdk 'rake notify[\"failed\"] -f rakefile_deploy.rb'"
+                      - "docker-compose run --rm chefdk 'rake notify[\"failed\"] -f rakefile_destroy.rb'"

--- a/gocd/cicdus/cicdus_teamcity_test_agent_destroy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_test_agent_destroy.gocd.yaml
@@ -14,7 +14,7 @@ pipelines:
       AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
       AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
       SLACK_URL_SUFFIX: AES:Gf9FJhvSPZvAwNUN6vrv6A==:8EV1Z57EwfIpksT47M2gV50E0DfJF/WeXnMdEDUvHO5X65AKqCwJEZUPR8fqpQnb
-    group: teamcity
+    group: teamcity_destroyer
     label_template: "${COUNT}"
     locking: off
     materials:

--- a/gocd/cicdus/cicdus_teamcity_test_agent_destroy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_test_agent_destroy.gocd.yaml
@@ -1,24 +1,19 @@
 pipelines:
-  "cicdus_teamcity_test_agent_deploy":
+  "cicdus_teamcity_test_agent_destroy":
     environment_variables:
       AWS_CRED_DIR: /var/go/.aws/
       AWS_DEFAULT_REGION: us-east-1
       CHEF_CONFIG_DIR: /etc/chef/
-      CHEF_SECRET_FILE: encrypted_data_bag_secret
       DC_USER: us\us_domjoin
       DOMAIN_CONTROLLER: us-dc01.us.daptiv.cloud
       EC2_ROLE_ARN: arn:aws:iam::147491244536:role/GO_CP_US_CICD
       NODE_TYPES: testagent_windows_chef13
-      PATCH_LEVEL: 20181014
-      WIN_DOMAIN_USER: us\us_deploysvc
-      WIN_LOCAL_USER: Administrator
+      PATCH_LEVEL:
     secure_variables: # https://api.gocd.org/current/#encrypt-a-plain-text-value
       DC_PASS: AES:w9NH2Zk+VRENh9UL7lmSew==:JEXZf0wrMwbjHqXAeMroUQ==
       AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
       AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
       SLACK_URL_SUFFIX: AES:Gf9FJhvSPZvAwNUN6vrv6A==:8EV1Z57EwfIpksT47M2gV50E0DfJF/WeXnMdEDUvHO5X65AKqCwJEZUPR8fqpQnb
-      WIN_DOMAIN_PASS: AES:eoSRfPVUr52uHiqjAhU2HA==:UZu+wR9bo8hQ4eQIDnhc34Kz8+OmVSqRXzKqVhIZB0M=
-      WIN_LOCAL_PASS: AES:+ScLaate2XUIW/7fPLstBw==:0ButywWhDkkQNig83ut7ww==
     group: teamcity
     label_template: "${COUNT}"
     locking: off
@@ -28,7 +23,7 @@ pipelines:
         branch: master
         destination: ops_ec2_deployer
     stages:
-      - "deploy":
+      - "destroyer":
           approval:
             type: manual
             roles:
@@ -36,7 +31,7 @@ pipelines:
               - US_GoCD_RoleTeamNetOps
           clean_workspace: true
           jobs:
-            "execute":
+            "destroy":
               resources:
                 - docker
               tasks:
@@ -53,25 +48,25 @@ pipelines:
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose run --rm chefdk 'rake notify[\"started\"] -f rakefile_deploy.rb'"
+                      - "docker-compose run --rm chefdk 'rake notify[\"started\"] -f rakefile_destroy.rb'"
                 - exec:
                     run_if: passed
                     working_directory: ops_ec2_deployer
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose -f docker-compose.yml run --rm chefdk 'gem uninstall winrm -v 2.2.3 --force && rake deploy -f rakefile_deploy.rb'"
+                      - "docker-compose run --rm chefdk 'rake destroy -f rakefile_destroy.rb'"
                 - exec:
                     run_if: passed
                     working_directory: ops_ec2_deployer
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose run --rm chefdk 'rake notify[\"passed\"] -f rakefile_deploy.rb'"
+                      - "docker-compose run --rm chefdk 'rake notify[\"passed\"] -f rakefile_destroy.rb'"
                 - exec:
                     run_if: failed
                     working_directory: ops_ec2_deployer
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose run --rm chefdk 'rake notify[\"failed\"] -f rakefile_deploy.rb'"
+                      - "docker-compose run --rm chefdk 'rake notify[\"failed\"] -f rakefile_destroy.rb'"

--- a/gocd/cicdus/cicdus_teamcity_ubuntu_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_ubuntu_agent_deploy.gocd.yaml
@@ -9,8 +9,8 @@ pipelines:
       TF_VARIABLE_FILE: us_cicd.tfvars
       TF_VARIABLE_PATH: ../../../terraform_environment/variables/
     secure_variables: # https://api.gocd.org/current/#encrypt-a-plain-text-value
-      GO_AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
-      GO_AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
+      AWS_ACCESS_KEY_ID: AES:TY5cRDBfU8wtIPQgf6xBTg==:m5Qb0NuLU8/GF/qYVBQL7wkbDOPfua00JctZmmA4jVw=
+      AWS_SECRET_ACCESS_KEY: AES:IHftjWeuET6YPR2ycwOT/A==:m9ghhk/rJuaa3RgrTPNpOpaeYNJa3ubPzr2DUGcuenKtfQG4n5b71Eni1Sn4R1Yn
       SLACK_URL_SUFFIX: AES:Gf9FJhvSPZvAwNUN6vrv6A==:8EV1Z57EwfIpksT47M2gV50E0DfJF/WeXnMdEDUvHO5X65AKqCwJEZUPR8fqpQnb
     group: teamcity
     label_template: "${COUNT}"
@@ -61,7 +61,11 @@ pipelines:
                           - -c
                           - "docker-compose run --rm terraform 'rake cleanup'"
       - "deploy":
-          approval: manual
+          approval:
+            type: manual
+            roles:
+              - US_GoCD_RoleTeamBork
+              - US_GoCD_RoleTeamNetOps
           clean_workspace: true
           jobs:
             "execute":


### PR DESCRIPTION
- Add destroyer pipelines for Windows TeamCity nodes.
- Add approval requirements to existing deployment pipelines.
- Drop 'GO_' from variables for AWS creds, sort variables.