### PR TITLE
new docker-compose image

### DIFF
--- a/terraform/teamcity_agent/docker-compose.yml
+++ b/terraform/teamcity_agent/docker-compose.yml
@@ -4,7 +4,7 @@
 version: '2'
 services:
   terraform:
-    image: daptiv/gocd-agent-ubuntu-16.04-terraform:0.11.6
+    image: daptiv/ubuntu-18.04-terraform:0.11.6
     volumes:
       - $PWD:/src/
       - ${AWS_CRED_DIR}:/root/.aws/


### PR DESCRIPTION
@brentbaumann 

Use new Ubuntu 18.04 container image for Terraform.