### PR TITLE
removed winrm uninstall command

### DIFF
--- a/gocd/cicdus/cicdus_teamcity_cognos_agent_deploy.gocd.yaml
+++ b/gocd/cicdus/cicdus_teamcity_cognos_agent_deploy.gocd.yaml
@@ -60,7 +60,7 @@ pipelines:
                     command: /bin/bash
                     arguments:
                       - -c
-                      - "docker-compose -f docker-compose.yml run --rm chefdk 'gem uninstall winrm -v 2.2.3 --force && rake deploy -f rakefile_deploy.rb'"
+                      - "docker-compose -f docker-compose.yml run --rm chefdk 'rake deploy -f rakefile_deploy.rb'"
                 - exec:
                     run_if: passed
                     working_directory: ops_ec2_deployer


### PR DESCRIPTION
winrm is not currently installed on the agents when the teamcity goagent deploy occurs, the uninstall command is not needed.

- [ ] @jtrinklein 
- [ ] @saxford 