### PR TITLE
Include recipe nodejs on linux box

### DIFF
--- a/chef/daptiv_teamcity/recipes/agent_linux.rb
+++ b/chef/daptiv_teamcity/recipes/agent_linux.rb
@@ -56,6 +56,9 @@ end
 daptiv_gem_config tc_local_user do
 end
 
+# Install npm
+include_recipe 'daptiv_nodejs'
+
 # Create npm config
 npm_auth_token = data_bag_item('teamcity', 'npm_auth_token')
 daptiv_nodejs_npm_config 'generate_teamcity_npmrc' do

--- a/chef/daptiv_teamcity/spec/spec_helper.rb
+++ b/chef/daptiv_teamcity/spec/spec_helper.rb
@@ -39,5 +39,6 @@ RSpec.configure do |config|
     )
     stub_command('getent group docker').and_return(true)
     stub_command('docker --help').and_return(true)
+    stub_command("npm -v 2>&1 | grep '6.14.13'").and_return(true)
   end
 end


### PR DESCRIPTION
I have no idea what I am doing in chef.

This is an attempt to get a non-ancient version of node (>6) and npm on these boxes, as we build npm packages with these agents.